### PR TITLE
Auto-publish: do not log notices

### DIFF
--- a/bin/npm-publish/index.ts
+++ b/bin/npm-publish/index.ts
@@ -46,6 +46,7 @@ try {
         'pub',
         `-w=${localPackageSpecs.name}`,
         `--tag=${tag}`,
+        '--loglevel=error',
       ])
     
       assert(!publishCmd.error, publishCmd.error)
@@ -60,6 +61,7 @@ try {
         `add`,
         `${localPackageSpecs.name}@${localPackageSpecs.version}`,
         tag,
+        '--loglevel=error',
       ])
     
       assert(!tagCmd.error, tagCmd.error)


### PR DESCRIPTION
refs #20

Action worked but threw an error because NPM logs notices on stderr (apparently on purpose), so now npm commands are set with a loglevel of `error`